### PR TITLE
Adjust to `!(AbstractQ <: AbstractMatrix)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteLinearAlgebra"
 uuid = "cde9dba0-b1de-11e9-2c62-0bab9446c55c"
-version = "0.6.13"
+version = "0.6.14"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/InfiniteLinearAlgebra.jl
+++ b/src/InfiniteLinearAlgebra.jl
@@ -5,7 +5,8 @@ using BlockArrays, BlockBandedMatrices, BandedMatrices, LazyArrays, LazyBandedMa
 
 import Base: +, -, *, /, \, ^, OneTo, getindex, promote_op, _unsafe_getindex, size, axes, length,
             AbstractMatrix, AbstractArray, Matrix, Array, Vector, AbstractVector, Slice,
-            show, getproperty, copy, copyto!, map, require_one_based_indexing, similar, inv
+            show, getproperty, copy, copyto!, map, require_one_based_indexing, similar, inv,
+            oneto, unitrange
 import Base.Broadcast: BroadcastStyle, Broadcasted, broadcasted
 
 import ArrayLayouts: colsupport, rowsupport, triangularlayout, MatLdivVec, triangulardata, TriangularLayout, TridiagonalLayout,
@@ -17,7 +18,7 @@ import FillArrays: AbstractFill, getindex_value, axes_print_matrix_row
 import InfiniteArrays: OneToInf, InfUnitRange, Infinity, PosInfinity, InfiniteCardinal, InfStepRange, AbstractInfUnitRange, InfAxes, InfRanges
 import LinearAlgebra: matprod, qr, AbstractTriangular, AbstractQ, adjoint, transpose, AdjOrTrans
 import LazyArrays: applybroadcaststyle, CachedArray, CachedMatrix, CachedVector, DenseColumnMajor, FillLayout, ApplyMatrix, check_mul_axes, LazyArrayStyle,
-                    resizedata!, MemoryLayout, most,
+                    resizedata!, MemoryLayout,
                     factorize, sub_materialize, LazyLayout, LazyArrayStyle, layout_getindex,
                     applylayout, ApplyLayout, PaddedLayout, CachedLayout, cacheddata, zero!, MulAddStyle,
                     LazyArray, LazyMatrix, LazyVector, paddeddata, arguments
@@ -40,16 +41,12 @@ import DSP: conv
 import SemiseparableMatrices: AbstractAlmostBandedLayout, _almostbanded_qr!
 
 
-if VERSION < v"1.6-"
-    oneto(n) = Base.OneTo(n)
-else
-    import Base: oneto, unitrange
+if VERSION ≥ v"1.7-"
+    LinearAlgebra._cut_B(x::AbstractVector, ::InfUnitRange) = x
+    LinearAlgebra._cut_B(X::AbstractMatrix, ::InfUnitRange) = X
 end
 
-if VERSION ≥ v"1.7-"
-    LinearAlgebra._cut_B(x::AbstractVector, r::InfUnitRange) = x
-    LinearAlgebra._cut_B(X::AbstractMatrix, r::InfUnitRange) = X
-end
+const AdjointQtype = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
 
 # BroadcastStyle(::Type{<:BandedMatrix{<:Any,<:Any,<:OneToInf}}) = LazyArrayStyle{2}()
 

--- a/src/banded/infbanded.jl
+++ b/src/banded/infbanded.jl
@@ -15,7 +15,7 @@ getindex(B::InfBandCartesianIndices, k::Int) = B.b ≥ 0 ? CartesianIndex(k, k+B
 
 Base.checkindex(::Type{Bool}, ::NTuple{2,OneToInf{Int}}, ::InfBandCartesianIndices) = true
 BandedMatrices.band_to_indices(_, ::NTuple{2,OneToInf{Int}}, b) = (InfBandCartesianIndices(b),)
-Base.BroadcastStyle(::Type{<:SubArray{<:Any,1,<:Any,Tuple{InfBandCartesianIndices}}}) = LazyArrayStyle{1}()
+BroadcastStyle(::Type{<:SubArray{<:Any,1,<:Any,Tuple{InfBandCartesianIndices}}}) = LazyArrayStyle{1}()
 
 _inf_banded_sub_materialize(_, V) = V
 function _inf_banded_sub_materialize(::BandedColumns, V)
@@ -487,7 +487,7 @@ for Typ in (:(LinearAlgebra.Tridiagonal{<:Any,<:InfFill}),
             :(LazyBandedMatrices.SymTridiagonal{<:Any,<:InfFill,<:InfFill}))
     @eval begin
         MemoryLayout(::Type{<:$Typ}) = TridiagonalToeplitzLayout()
-        Base.BroadcastStyle(::Type{<:$Typ}) = LazyArrayStyle{2}()
+        BroadcastStyle(::Type{<:$Typ}) = LazyArrayStyle{2}()
     end
 end
 
@@ -497,7 +497,7 @@ for Typ in (:(LinearAlgebra.Bidiagonal{<:Any,<:InfFill}),
             :(LazyBandedMatrices.Bidiagonal{<:Any,<:InfFill,<:InfFill}))
     @eval begin
         MemoryLayout(::Type{<:$Typ}) = BidiagonalToeplitzLayout()
-        Base.BroadcastStyle(::Type{<:$Typ}) = LazyArrayStyle{2}()
+        BroadcastStyle(::Type{<:$Typ}) = LazyArrayStyle{2}()
     end
 end
 

--- a/src/banded/infqltoeplitz.jl
+++ b/src/banded/infqltoeplitz.jl
@@ -88,10 +88,18 @@ struct ProductQ{T,QQ<:Tuple} <: LayoutQ{T}
     Qs::QQ
 end
 
-ArrayLayouts.@layoutmatrix ProductQ
-ArrayLayouts.@_layoutlmul ProductQ
+if VERSION < v"1.10-"
+    ArrayLayouts.@layoutmatrix ProductQ
+    ArrayLayouts.@_layoutlmul ProductQ
+else # ArrayLayouts.@layoutmatrix ProductQ without ArrayLayouts.@layoutgetindex
+    ArrayLayouts.@layoutldiv ProductQ
+    ArrayLayouts.@layoutmul ProductQ
+    ArrayLayouts.@layoutlmul ProductQ
+    ArrayLayouts.@layoutfactorizations ProductQ
+    ArrayLayouts.@_layoutlmul ProductQ
+end
 
-ProductQ(Qs::AbstractMatrix...) = ProductQ{mapreduce(eltype, promote_type, Qs),typeof(Qs)}(Qs)
+ProductQ(Qs::Union{AbstractMatrix,AbstractQ}...) = ProductQ{mapreduce(eltype, promote_type, Qs),typeof(Qs)}(Qs)
 
 adjoint(Q::ProductQ) = ProductQ(reverse(map(adjoint, Q.Qs))...)
 
@@ -105,14 +113,21 @@ function lmul!(Q::ProductQ, v::AbstractVecOrMat)
     v
 end
 
-# Avoid ambiguities
-getindex(Q::ProductQ, i::Int, j::Int) = Q[:, j][i]
+if VERSION < v"1.8-"
+    # Avoid ambiguities
+    getindex(Q::ProductQ, i::Int, j::Int) = Q[:, j][i]
 
-function getindex(Q::ProductQ, ::Colon, j::Int)
-    y = zeros(eltype(Q), size(Q, 2))
-    y[j] = 1
-    lmul!(Q, y)
+    function getindex(Q::ProductQ, ::Colon, j::Int)
+        y = zeros(eltype(Q), size(Q, 2))
+        y[j] = 1
+        lmul!(Q, y)
+    end
 end
+if VERSION >= v"1.10-"
+    getindex(Q::ProductQ, I::AbstractVector{Int}, J::AbstractVector{Int}) =
+        hcat((Q[:,j][I] for j in J)...)
+end
+
 getindex(Q::ProductQ{<:Any,<:Tuple{Vararg{LowerHessenbergQ}}}, i::Int, j::Int) = (Q')[j, i]'
 
 function _productq_mul(A::ProductQ{T}, x::AbstractVector{S}) where {T,S}

--- a/src/banded/infqltoeplitz.jl
+++ b/src/banded/infqltoeplitz.jl
@@ -88,7 +88,7 @@ struct ProductQ{T,QQ<:Tuple} <: LayoutQ{T}
     Qs::QQ
 end
 
-if VERSION < v"1.10-"
+if VERSION < v"1.8-"
     ArrayLayouts.@layoutmatrix ProductQ
     ArrayLayouts.@_layoutlmul ProductQ
 else # ArrayLayouts.@layoutmatrix ProductQ without ArrayLayouts.@layoutgetindex

--- a/src/blockbanded/blockbanded.jl
+++ b/src/blockbanded/blockbanded.jl
@@ -1,4 +1,4 @@
-const OneToInfCumsum = InfiniteArrays.RangeCumsum{Int,OneToInf{Int}}
+const OneToInfCumsum = RangeCumsum{Int,OneToInf{Int}}
 
 BlockArrays.sortedunion(::AbstractVector{<:PosInfinity}, ::AbstractVector{<:PosInfinity}) = [∞]
 function BlockArrays.sortedunion(::AbstractVector{<:PosInfinity}, b)

--- a/src/infql.jl
+++ b/src/infql.jl
@@ -145,7 +145,7 @@ end
 function materialize!(M::Lmul{<:AdjQLPackedQLayout{<:BandedColumns},<:PaddedLayout})
     adjA,B = M.A,M.B
     require_one_based_indexing(B)
-    A = adjA.parent
+    A = parent(adjA)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
     if mA != mB
@@ -179,9 +179,9 @@ function _lmul_cache(A::AbstractMatrix{T}, x::AbstractVector{S}) where {T,S}
 end
 
 (*)(A::QLPackedQ{T,<:InfBandedMatrix}, x::AbstractVector) where {T} = _lmul_cache(A, x)
-(*)(A::Adjoint{T,<:QLPackedQ{T,<:InfBandedMatrix}}, x::AbstractVector) where {T} = _lmul_cache(A, x)
+(*)(A::AdjointQtype{T,<:QLPackedQ{T,<:InfBandedMatrix}}, x::AbstractVector) where {T} = _lmul_cache(A, x)
 (*)(A::QLPackedQ{T,<:InfBandedMatrix}, x::LazyVector) where {T} = _lmul_cache(A, x)
-(*)(A::Adjoint{T,<:QLPackedQ{T,<:InfBandedMatrix}}, x::LazyVector) where {T} = _lmul_cache(A, x)
+(*)(A::AdjointQtype{T,<:QLPackedQ{T,<:InfBandedMatrix}}, x::LazyVector) where {T} = _lmul_cache(A, x)
 
 
 function blocktailiterate(c,a,b, d=c, e=a)
@@ -230,9 +230,9 @@ ql(A::Adjoint{T,BlockTriPertToeplitz{T}}) where T = ql(BlockTridiagonal(A))
 
 const InfBlockBandedMatrix{T} = BlockSkylineMatrix{T,<:Vcat{T,1,<:Tuple{Vector{T},<:BlockArray{T,1,<:Fill{<:Any,1,Tuple{OneToInf{Int64}}}}}}}
 
-function lmul!(adjA::Adjoint{<:Any,<:QLPackedQ{<:Any,<:InfBlockBandedMatrix}}, B::AbstractVector)
+function lmul!(adjA::AdjointQtype{<:Any,<:QLPackedQ{<:Any,<:InfBlockBandedMatrix}}, B::AbstractVector)
     require_one_based_indexing(B)
-    A = adjA.parent
+    A = parent(adjA)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
     if mA != mB
@@ -270,7 +270,7 @@ function (*)(A::QLPackedQ{T,<:InfBlockBandedMatrix}, x::AbstractVector{S}) where
     lmul!(A, cache(convert(AbstractVector{TS},x)))
 end
 
-function (*)(A::Adjoint{T,<:QLPackedQ{T,<:InfBlockBandedMatrix}}, x::AbstractVector{S}) where {T,S}
+function (*)(A::AdjointQtype{T,<:QLPackedQ{T,<:InfBlockBandedMatrix}}, x::AbstractVector{S}) where {T,S}
     TS = promote_op(matprod, T, S)
     lmul!(A, cache(convert(AbstractVector{TS},x)))
 end
@@ -308,7 +308,7 @@ _data_tail(::CachedLayout, a) = cacheddata(a), getindex_value(a.array)
 function _data_tail(::ApplyLayout{typeof(vcat)}, a)
     args = arguments(vcat, a)
     dat,tl = _data_tail(last(args))
-    vcat(most(args)..., dat), tl
+    vcat(Base.front(args)..., dat), tl
 end
 _data_tail(a) = _data_tail(MemoryLayout(a), a)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,7 +150,7 @@ include("test_infbanded.jl")
             N = 1000
             v = view(n, Block.(Base.OneTo(N)))
             @test view(v, Block(2)) ≡ Fill(2, 2)
-            @test axes(v) isa Tuple{BlockedUnitRange{InfiniteArrays.RangeCumsum{Int64,Base.OneTo{Int64}}}}
+            @test axes(v) isa Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64,Base.OneTo{Int64}}}}
             @test @allocated(axes(v)) ≤ 40
 
             dest = PseudoBlockArray{Float64}(undef, axes(v))
@@ -159,7 +159,7 @@ include("test_infbanded.jl")
 
             v = view(k, Block.(Base.OneTo(N)))
             @test view(v, Block(2)) ≡ Base.OneTo(2)
-            @test axes(v) isa Tuple{BlockedUnitRange{InfiniteArrays.RangeCumsum{Int64,Base.OneTo{Int64}}}}
+            @test axes(v) isa Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64,Base.OneTo{Int64}}}}
             @test @allocated(axes(v)) ≤ 40
             @test copyto!(dest, v) == v
 
@@ -173,7 +173,7 @@ include("test_infbanded.jl")
             @test v[Block(1)] == 1:2
             @test v[Block(1)] ≡ k[Block(2)] ≡ Base.OneTo(2)
 
-            @test axes(n, 1) isa BlockedUnitRange{InfiniteArrays.RangeCumsum{Int64,OneToInf{Int64}}}
+            @test axes(n, 1) isa BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64,OneToInf{Int64}}}
         end
 
         @testset "BlockHcat copyto!" begin

--- a/test/test_hessenbergq.jl
+++ b/test/test_hessenbergq.jl
@@ -6,42 +6,50 @@ import InfiniteLinearAlgebra: UpperHessenbergQ, LowerHessenbergQ, tail_de, _Band
         c,s = cos(0.1), sin(0.1); q = [c s; s -c];
         Q = UpperHessenbergQ(Fill(q,1))
         @test size(Q) == (size(Q,1),size(Q,2)) == (2,2)
-        @test Q ≈ q
+        @test all(j -> Q[:,j] ≈ q[:,j], axes(Q, 2))
         Q = UpperHessenbergQ(Fill(q,2))
         @test bandwidths(Q) == (1,2)
-        @test Q ≈ [q zeros(2); zeros(1,2) 1] * [1 zeros(1,2); zeros(2) q]
+        QM = [q zeros(2); zeros(1,2) 1] * [1 zeros(1,2); zeros(2) q]
+        @test all(j -> Q[:,j] ≈ QM[:,j], axes(Q, 2))
         @test Q' isa LowerHessenbergQ
-        @test Q' ≈ [1 zeros(1,2); zeros(2) q'] * [q' zeros(2); zeros(1,2) 1]
+        QM = [1 zeros(1,2); zeros(2) q'] * [q' zeros(2); zeros(1,2) 1]
+        @test all(j -> Q'[:,j] ≈ QM[:,j], axes(Q, 2))
 
         q = qr(randn(2,2) + im*randn(2,2)).Q
         Q = UpperHessenbergQ(Fill(q,1))
-        @test Q ≈ q
+        @test all(j -> Q[:,j] ≈ q[:,j], axes(Q, 2))
         Q = UpperHessenbergQ(Fill(q,2))
         @test bandwidths(Q) == (1,2)
-        @test Q ≈ [q zeros(2); zeros(1,2) 1] * [1 zeros(1,2); zeros(2) q]
+        QM = [Matrix(q) zeros(2); zeros(1,2) 1] * [1 zeros(1,2); zeros(2) Matrix(q)]
+        @test all(j -> Q[:,j] ≈ QM[:,j], axes(Q, 2))
         @test Q' isa LowerHessenbergQ
-        @test Q' ≈ [1 zeros(1,2); zeros(2) q'] * [q' zeros(2); zeros(1,2) 1]
+        QM = [1 zeros(1,2); zeros(2) Matrix(q')] * [Matrix(q') zeros(2); zeros(1,2) 1]
+        @test all(j -> Q'[:,j] ≈ QM[:,j], axes(Q, 2))
     end
 
     @testset "finite LowerHessenbergQ" begin
         c,s = cos(0.1), sin(0.1); q = [c s; s -c];
         Q = LowerHessenbergQ(Fill(q,1))
         @test size(Q) == (size(Q,1),size(Q,2)) == (2,2)
-        @test Q ≈ q
+        @test all(j -> Q[:,j] ≈ q[:,j], axes(Q, 2))
         Q = LowerHessenbergQ(Fill(q,2))
         @test bandwidths(Q) == (2,1)
-        @test Q ≈ [1 zeros(1,2); zeros(2) q] * [q zeros(2); zeros(1,2) 1]
+        QM = [1 zeros(1,2); zeros(2) q] * [q zeros(2); zeros(1,2) 1]
+        @test all(j -> Q[:,j] ≈ QM[:,j], axes(Q, 2))
         @test Q' isa UpperHessenbergQ
-        @test Q' ≈ [q' zeros(2); zeros(1,2) 1]  * [1 zeros(1,2); zeros(2) q']
+        QM = [q' zeros(2); zeros(1,2) 1]  * [1 zeros(1,2); zeros(2) q']
+        @test all(j -> Q'[:,j] ≈ QM[:,j], axes(Q, 2))
 
         q = qr(randn(2,2) + im*randn(2,2)).Q
         Q = LowerHessenbergQ(Fill(q,1))
-        @test Q ≈ q
+        @test all(j -> Q[:,j] ≈ q[:,j], axes(Q, 2))
         Q = LowerHessenbergQ(Fill(q,2))
         @test bandwidths(Q) == (2,1)
-        @test Q ≈ [1 zeros(1,2); zeros(2) q] * [q zeros(2); zeros(1,2) 1]
+        QM = [1 zeros(1,2); zeros(2) Matrix(q)] * [Matrix(q) zeros(2); zeros(1,2) 1]
+        @test all(j -> Q[:,j] ≈ QM[:,j], axes(Q, 2))
         @test Q' isa UpperHessenbergQ
-        @test Q' ≈ [q' zeros(2); zeros(1,2) 1]  * [1 zeros(1,2); zeros(2) q']
+        QM = [Matrix(q') zeros(2); zeros(1,2) 1] * [1 zeros(1,2); zeros(2) Matrix(q')]
+        @test all(j -> Q'[:,j] ≈ QM[:,j], axes(Q, 2))
     end
 
     @testset "infinite-Q" begin
@@ -56,9 +64,9 @@ import InfiniteLinearAlgebra: UpperHessenbergQ, LowerHessenbergQ, tail_de, _Band
         for T in (Float64, ComplexF64)
             A = brand(T,10,10,1,1)
             Q,R = qr(A)
-            @test UpperHessenbergQ(Q) ≈ Q
+            @test all(j -> UpperHessenbergQ(Q)[:,j] ≈ Q[:,j], axes(Q, 2))
             Q,L = ql(A)
-            @test LowerHessenbergQ(Q) ≈ Q
+            @test all(j -> LowerHessenbergQ(Q)[:,j] ≈ Q[:,j], axes(Q, 2))
         end
     end
 end


### PR DESCRIPTION
This makes the package future proof for https://github.com/JuliaLang/julia/pull/46196. Some of the tests look complicated which is due to the fact that `Matrix(Q)` doesn't work.