### PR TITLE
Fix indexing/slicing of `ProductQ` and infinite `QLPackedQ`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteLinearAlgebra"
 uuid = "cde9dba0-b1de-11e9-2c62-0bab9446c55c"
-version = "0.6.14"
+version = "0.6.15"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -27,7 +27,7 @@ FillArrays = "0.13"
 InfiniteArrays = "0.12"
 LazyArrays = "0.22"
 LazyBandedMatrices = "0.8.4"
-MatrixFactorizations = "0.9.2"
+MatrixFactorizations = "0.9.6"
 SemiseparableMatrices = "0.3"
 julia = "1.6"
 

--- a/src/banded/infqltoeplitz.jl
+++ b/src/banded/infqltoeplitz.jl
@@ -123,10 +123,8 @@ if VERSION < v"1.8-"
         lmul!(Q, y)
     end
 end
-if VERSION >= v"1.10-"
-    getindex(Q::ProductQ, I::AbstractVector{Int}, J::AbstractVector{Int}) =
+getindex(Q::ProductQ, I::AbstractVector{Int}, J::AbstractVector{Int}) =
         hcat((Q[:,j][I] for j in J)...)
-end
 
 getindex(Q::ProductQ{<:Any,<:Tuple{Vararg{LowerHessenbergQ}}}, i::Int, j::Int) = (Q')[j, i]'
 

--- a/src/infql.jl
+++ b/src/infql.jl
@@ -94,6 +94,8 @@ end
 
 getindex(Q::QLPackedQ{T,<:InfBandedMatrix{T}}, i::Int, j::Int) where T =
     (Q'*[Zeros{T}(i-1); one(T); Zeros{T}(∞)])[j]'
+getindex(Q::QLPackedQ{<:Any,<:InfBandedMatrix}, I::AbstractVector{Int}, J::AbstractVector{Int}) =
+    [Q[i,j] for i in I, j in J]
 
 getL(Q::QL, ::NTuple{2,InfiniteCardinal{0}}) = LowerTriangular(Q.factors)
 getL(Q::QLHessenberg, ::NTuple{2,InfiniteCardinal{0}}) = LowerTriangular(Q.factors)
@@ -173,7 +175,7 @@ function materialize!(M::Lmul{<:AdjQLPackedQLayout{<:BandedColumns},<:PaddedLayo
     B
 end
 
-function _lmul_cache(A::AbstractMatrix{T}, x::AbstractVector{S}) where {T,S}
+function _lmul_cache(A::Union{AbstractMatrix{T},AbstractQ{T}}, x::AbstractVector{S}) where {T,S}
     TS = promote_op(matprod, T, S)
     lmul!(A, cache(convert(AbstractVector{TS},x)))
 end
@@ -264,6 +266,8 @@ end
 
 getindex(Q::QLPackedQ{T,<:InfBlockBandedMatrix{T}}, i::Integer, j::Integer) where T =
     (Q'*Vcat(Zeros{T}(i-1), one(T), Zeros{T}(∞)))[j]'
+getindex(Q::QLPackedQ{<:Any,<:InfBlockBandedMatrix}, I::AbstractVector{Int}, J::AbstractVector{Int}) =
+    [Q[i,j] for i in I, j in J]
 
 function (*)(A::QLPackedQ{T,<:InfBlockBandedMatrix}, x::AbstractVector{S}) where {T,S}
     TS = promote_op(matprod, T, S)


### PR DESCRIPTION
This fixes issues that arose in a mismatch between MatrixFactorizations.jl and InfiniteLinearAlgeba.jl.