### PR TITLE
Fix block axis element type in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ include("test_infbanded.jl")
         @test c[Block.(2:∞)][Block.(2:10)] == c[Block.(3:11)]
 
         @test length(axes(b, 1)) ≡ ℵ₀
-        @test last(axes(b, 1)) ≡ RealInfinity()
+        @test last(axes(b, 1)) ≡ ℵ₀
         @test Base.BroadcastStyle(typeof(b)) isa LazyArrayStyle{1}
 
         @test unitblocks(oneto(∞)) ≡ blockedrange(Ones{Int}(∞))


### PR DESCRIPTION
This should fix the failure seen in https://github.com/JuliaArrays/BlockArrays.jl/pull/260

Perhaps we should test for equality instead of `===` in this test, since the length is checked in the previous line? This would make the test pass with older versions of `BlockArrays` as well.