### PR TITLE
SymTridiagonal support for cholesky

### DIFF
--- a/src/InfiniteLinearAlgebra.jl
+++ b/src/InfiniteLinearAlgebra.jl
@@ -30,7 +30,7 @@ import BlockArrays: AbstractBlockVecOrMat, sizes_from_blocks, _length, BlockedUn
 import BandedMatrices: BandedMatrix, bandwidths, AbstractBandedLayout, _banded_qr!, _banded_qr, _BandedMatrix, banded_chol!
 
 import LazyBandedMatrices: ApplyBandedLayout, BroadcastBandedLayout, _krontrav_axes, _block_interlace_axes, LazyBandedLayout, AbstractLazyBandedBlockBandedLayout,
-                            AbstractLazyBandedLayout, OneToCumsum, BlockSlice1, KronTravBandedBlockBandedLayout, krontravargs, _broadcast_sub_arguments, BlockVec
+                            AbstractLazyBandedLayout, OneToCumsum, BlockSlice1, KronTravBandedBlockBandedLayout, krontravargs, _broadcast_sub_arguments, BlockVec, SymTridiagonal
 
 import BlockBandedMatrices: _BlockSkylineMatrix, _BandedMatrix, _BlockSkylineMatrix, blockstart, blockstride,
         BlockSkylineSizes, BlockSkylineMatrix, BlockBandedMatrix, _BlockBandedMatrix, BlockTridiagonal,

--- a/src/InfiniteLinearAlgebra.jl
+++ b/src/InfiniteLinearAlgebra.jl
@@ -30,7 +30,7 @@ import BlockArrays: AbstractBlockVecOrMat, sizes_from_blocks, _length, BlockedUn
 import BandedMatrices: BandedMatrix, bandwidths, AbstractBandedLayout, _banded_qr!, _banded_qr, _BandedMatrix, banded_chol!
 
 import LazyBandedMatrices: ApplyBandedLayout, BroadcastBandedLayout, _krontrav_axes, _block_interlace_axes, LazyBandedLayout, AbstractLazyBandedBlockBandedLayout,
-                            AbstractLazyBandedLayout, OneToCumsum, BlockSlice1, KronTravBandedBlockBandedLayout, krontravargs, _broadcast_sub_arguments, BlockVec, SymTridiagonal
+                            AbstractLazyBandedLayout, OneToCumsum, BlockSlice1, KronTravBandedBlockBandedLayout, krontravargs, _broadcast_sub_arguments, BlockVec
 
 import BlockBandedMatrices: _BlockSkylineMatrix, _BandedMatrix, _BlockSkylineMatrix, blockstart, blockstride,
         BlockSkylineSizes, BlockSkylineMatrix, BlockBandedMatrix, _BlockBandedMatrix, BlockTridiagonal,

--- a/src/infcholesky.jl
+++ b/src/infcholesky.jl
@@ -7,7 +7,9 @@ end
 size(U::AdaptiveCholeskyFactors) = size(U.data.array)
 bandwidths(A::AdaptiveCholeskyFactors) = (0,bandwidth(A.data,2))
 
-function AdaptiveCholeskyFactors(::SymmetricLayout{<:AbstractBandedLayout}, S::AbstractMatrix{T}) where T
+const SymmetricBandedLayouts = Union{SymTridiagonalLayout,SymmetricLayout{<:AbstractBandedLayout},DiagonalLayout}
+
+function AdaptiveCholeskyFactors(::SymmetricBandedLayouts, S::AbstractMatrix{T}) where T
     A = parent(S)
     l,u = bandwidths(A)
     data = BandedMatrix{T}(undef,(0,0),(l,u)) # pad super
@@ -45,7 +47,7 @@ end
 adaptivecholesky(A) = Cholesky(AdaptiveCholeskyFactors(A), :U, 0)
 
 
-ArrayLayouts._cholesky(::SymmetricLayout{<:AbstractBandedLayout}, ::NTuple{2,OneToInf{Int}}, A, ::CNoPivot) = adaptivecholesky(A)
+ArrayLayouts._cholesky(::SymmetricBandedLayouts, ::NTuple{2,OneToInf{Int}}, A, ::CNoPivot) = adaptivecholesky(A)
 
 function colsupport(F::AdaptiveCholeskyFactors, j)
     partialcholesky!(F, maximum(j)+bandwidth(F,2))

--- a/src/infcholesky.jl
+++ b/src/infcholesky.jl
@@ -47,7 +47,8 @@ end
 adaptivecholesky(A) = Cholesky(AdaptiveCholeskyFactors(A), :U, 0)
 
 
-ArrayLayouts._cholesky(::SymmetricBandedLayouts, ::NTuple{2,OneToInf{Int}}, A, ::CNoPivot) = adaptivecholesky(A)
+ArrayLayouts._cholesky(::SymTridiagonalLayout, ::NTuple{2,OneToInf{Int}}, A, ::CNoPivot) = adaptivecholesky(A)
+ArrayLayouts._cholesky(::SymmetricLayout{<:AbstractBandedLayout}, ::NTuple{2,OneToInf{Int}}, A, ::CNoPivot) = adaptivecholesky(A)
 
 function colsupport(F::AdaptiveCholeskyFactors, j)
     partialcholesky!(F, maximum(j)+bandwidth(F,2))

--- a/test/test_infcholesky.jl
+++ b/test/test_infcholesky.jl
@@ -1,4 +1,5 @@
-using InfiniteLinearAlgebra, LinearAlgebra, BandedMatrices, ArrayLayouts, Test
+using InfiniteLinearAlgebra, LinearAlgebra, BandedMatrices, ArrayLayouts, LazyBandedMatrices, Test
+import InfiniteLinearAlgebra: SymmetricBandedLayouts
 
 @testset "infinite-cholesky" begin
     S = Symmetric(BandedMatrix(0 => 1:∞, 1=> Ones(∞)))
@@ -10,9 +11,15 @@ using InfiniteLinearAlgebra, LinearAlgebra, BandedMatrices, ArrayLayouts, Test
     @test cholesky(S) \ b ≈ qr(S) \ b ≈ S \ b
 
     @testset "singularly perturbed" begin
+        # using Symmetric(BandedMatrix(...))
         ε = 0.0001
         S = Symmetric(BandedMatrix(0 => 2 .+ ε*(1:∞), 1=> -Ones(∞)))
         b = [1; zeros(∞)]
+        @test cholesky(S) \ b ≈  S \ b
+        # using SymTridiagonal(...)
+        ε = 0.0001
+        S = LazyBandedMatrices.SymTridiagonal(2 .+ ε*(1:∞), -Ones(∞))
+        @test MemoryLayout(S) isa SymmetricBandedLayouts
         @test cholesky(S) \ b ≈  S \ b
     end
 


### PR DESCRIPTION
Fix https://github.com/JuliaLinearAlgebra/InfiniteLinearAlgebra.jl/issues/124

Makes `cholesky` accept `SymTridiagonal`.