### PR TITLE
Mode DSP to an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteLinearAlgebra"
 uuid = "cde9dba0-b1de-11e9-2c62-0bab9446c55c"
-version = "0.6.22"
+version = "0.6.23"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -15,6 +15,12 @@ LazyBandedMatrices = "d7e5e226-e90b-4449-9968-0f923699bf6f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MatrixFactorizations = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
 SemiseparableMatrices = "f8ebbe35-cbfb-4060-bf7f-b10e4670cf57"
+
+[weakdeps]
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+
+[extensions]
+InfiniteLinearAlgebraDSPExt = "DSP"
 
 [compat]
 Aqua = "0.6"
@@ -33,10 +39,11 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "Random", "SpecialFunctions", "StaticArrays"]
+test = ["Aqua", "DSP", "Test", "Random", "SpecialFunctions", "StaticArrays"]

--- a/ext/InfiniteLinearAlgebraDSPExt.jl
+++ b/ext/InfiniteLinearAlgebraDSPExt.jl
@@ -1,3 +1,13 @@
+module InfiniteLinearAlgebraDSPExt
+
+using InfiniteLinearAlgebra
+using InfiniteArrays
+using InfiniteArrays: InfRanges, OneToInf
+using FillArrays
+using FillArrays: AbstractFill, getindex_value
+using LazyArrays
+import DSP: conv
+
 
 ##
 # conv
@@ -67,4 +77,7 @@ end
 function conv(r1::Ones{<:Any,1,<:Tuple{<:OneToInf}}, r2::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}})
     a = getindex_value(r1) * getindex_value(r2)
     a:a:∞
+end
+
+
 end

--- a/src/InfiniteLinearAlgebra.jl
+++ b/src/InfiniteLinearAlgebra.jl
@@ -36,8 +36,6 @@ import BlockBandedMatrices: _BlockSkylineMatrix, _BandedMatrix, _BlockSkylineMat
         BlockSkylineSizes, BlockSkylineMatrix, BlockBandedMatrix, _BlockBandedMatrix, BlockTridiagonal,
         AbstractBlockBandedLayout, _blockbanded_qr!, BlockBandedLayout
 
-import DSP: conv
-
 import SemiseparableMatrices: AbstractAlmostBandedLayout, _almostbanded_qr!
 
 
@@ -118,8 +116,6 @@ pad(c::BlockVec, ax::BlockedUnitRange{<:InfStepRange}) = BlockVec(pad(c.args[1],
 
 export Vcat, Fill, ql, ql!, ∞, ContinuousSpectrumError, BlockTridiagonal
 
-include("infconv.jl")
-
 include("banded/hessenbergq.jl")
 
 include("banded/infbanded.jl")
@@ -130,5 +126,9 @@ include("infqr.jl")
 include("inful.jl")
 include("infcholesky.jl")
 
+
+if !isdefined(Base, :get_extension)
+    include("../ext/InfiniteLinearAlgebraDSPExt.jl")
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,12 @@ import LazyBandedMatrices: BroadcastBandedBlockBandedLayout, BroadcastBandedLayo
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(InfiniteLinearAlgebra, ambiguities=false, unbound_args=false, piracy=false)
+    Aqua.test_all(InfiniteLinearAlgebra, ambiguities=false, unbound_args=false, piracy=false,
+        # Project.toml formatting issue on v1.6
+        # Pkg issue: https://github.com/JuliaLang/Pkg.jl/issues/3481
+        # Aqua workaround: https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
+        # we only check the formatting on more recent versions
+        project_toml_formatting = VERSION>=v"1.7")
 end
 
 @testset "chop" begin


### PR DESCRIPTION
On master
```julia
julia> @time using InfiniteLinearAlgebra
  5.246290 seconds (9.16 M allocations: 876.811 MiB, 4.52% gc time, 0.33% compilation time)
```
This PR
```julia
julia> @time using InfiniteLinearAlgebra
  4.303242 seconds (8.09 M allocations: 800.929 MiB, 4.00% gc time, 0.14% compilation time)
```
Also, since some of these methods are committing type-piracy, it's better for them to not be loaded unconditionally.