### PR TITLE
Fix cholesky.L and bugs related to copy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteLinearAlgebra"
 uuid = "cde9dba0-b1de-11e9-2c62-0bab9446c55c"
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infcholesky.jl
+++ b/src/infcholesky.jl
@@ -19,7 +19,7 @@ AdaptiveCholeskyFactors(A::AbstractMatrix{T}) where T = AdaptiveCholeskyFactors(
 MemoryLayout(::Type{AdaptiveCholeskyFactors{T,DM,M}}) where {T,DM,M} = AdaptiveLayout{typeof(MemoryLayout(DM))}()
 
 copy(A::AdaptiveCholeskyFactors) = A
-copy(A::Adjoint{T,<:AdaptiveCholeskyFactors}) where T = A
+copy(A::Adjoint{T,<:AdaptiveCholeskyFactors}) where T = copy(parent(A))'
 
 function partialcholesky!(F::AdaptiveCholeskyFactors{T,<:BandedMatrix}, n::Int) where T
     if n > F.ncols

--- a/src/infcholesky.jl
+++ b/src/infcholesky.jl
@@ -19,7 +19,8 @@ AdaptiveCholeskyFactors(A::AbstractMatrix{T}) where T = AdaptiveCholeskyFactors(
 MemoryLayout(::Type{AdaptiveCholeskyFactors{T,DM,M}}) where {T,DM,M} = AdaptiveLayout{typeof(MemoryLayout(DM))}()
 
 copy(A::AdaptiveCholeskyFactors) = AdaptiveCholeskyFactors(copy(A.data), copy(A.ncols))
-copy(A::AdjOrTrans{T,<:AdaptiveCholeskyFactors}) where T = copy(parent(A))'
+copy(A::Adjoint{T,<:AdaptiveCholeskyFactors}) where T = copy(parent(A))'
+copy(A::Transpose{T,<:AdaptiveCholeskyFactors}) where T = transpose(copy(parent(A)))
 
 function partialcholesky!(F::AdaptiveCholeskyFactors{T,<:BandedMatrix}, n::Int) where T
     if n > F.ncols

--- a/src/infcholesky.jl
+++ b/src/infcholesky.jl
@@ -18,6 +18,8 @@ end
 AdaptiveCholeskyFactors(A::AbstractMatrix{T}) where T = AdaptiveCholeskyFactors(MemoryLayout(A), A)
 MemoryLayout(::Type{AdaptiveCholeskyFactors{T,DM,M}}) where {T,DM,M} = AdaptiveLayout{typeof(MemoryLayout(DM))}()
 
+copy(A::AdaptiveCholeskyFactors) = A
+copy(A::Adjoint{T,<:AdaptiveCholeskyFactors}) where T = A
 
 function partialcholesky!(F::AdaptiveCholeskyFactors{T,<:BandedMatrix}, n::Int) where T
     if n > F.ncols

--- a/src/infcholesky.jl
+++ b/src/infcholesky.jl
@@ -18,8 +18,8 @@ end
 AdaptiveCholeskyFactors(A::AbstractMatrix{T}) where T = AdaptiveCholeskyFactors(MemoryLayout(A), A)
 MemoryLayout(::Type{AdaptiveCholeskyFactors{T,DM,M}}) where {T,DM,M} = AdaptiveLayout{typeof(MemoryLayout(DM))}()
 
-copy(A::AdaptiveCholeskyFactors) = A
-copy(A::Adjoint{T,<:AdaptiveCholeskyFactors}) where T = copy(parent(A))'
+copy(A::AdaptiveCholeskyFactors) = AdaptiveCholeskyFactors(copy(A.data), copy(A.ncols))
+copy(A::AdjOrTrans{T,<:AdaptiveCholeskyFactors}) where T = copy(parent(A))'
 
 function partialcholesky!(F::AdaptiveCholeskyFactors{T,<:BandedMatrix}, n::Int) where T
     if n > F.ncols

--- a/test/test_infcholesky.jl
+++ b/test/test_infcholesky.jl
@@ -1,5 +1,5 @@
 using InfiniteLinearAlgebra, LinearAlgebra, BandedMatrices, ArrayLayouts, LazyBandedMatrices, Test
-import InfiniteLinearAlgebra: SymmetricBandedLayouts
+import InfiniteLinearAlgebra: SymmetricBandedLayouts, AdaptiveCholeskyFactors
 
 @testset "infinite-cholesky" begin
     S = Symmetric(BandedMatrix(0 => 1:∞, 1=> Ones(∞)))
@@ -15,9 +15,15 @@ import InfiniteLinearAlgebra: SymmetricBandedLayouts
         A = BandedMatrix(0 => -2*(0:∞)/z, 1 => Ones(∞), -1 => Ones(∞));
         M = Symmetric(I-A)
         chol = cholesky(M)
+
+        # test consistency
+        @test copy(chol.factors) isa AdaptiveCholeskyFactors
+        @test copy(chol.factors') isa Adjoint
+        @test copy(transpose(chol.factors)) isa Transpose
     
         # test copy
         @test (chol.factors')[1:10,1:10] == copy(chol.factors')[1:10,1:10]
+        @test transpose(chol.factors)[1:10,1:10] == copy(chol.factors')[1:10,1:10]
         @test (chol.factors)[1:10,1:10] == copy(chol.factors)[1:10,1:10]
     
         # test fetching L factor

--- a/test/test_infcholesky.jl
+++ b/test/test_infcholesky.jl
@@ -10,6 +10,22 @@ import InfiniteLinearAlgebra: SymmetricBandedLayouts
     b = [randn(10_000); zeros(∞)]
     @test cholesky(S) \ b ≈ qr(S) \ b ≈ S \ b
 
+    @testset "copying and L factor" begin
+        z = 10_000;
+        A = BandedMatrix(0 => -2*(0:∞)/z, 1 => Ones(∞), -1 => Ones(∞));
+        M = Symmetric(I-A)
+        chol = cholesky(M)
+    
+        # test copy
+        @test (chol.factors')[1:10,1:10] == copy(chol.factors')[1:10,1:10]
+        @test (chol.factors)[1:10,1:10] == copy(chol.factors)[1:10,1:10]
+    
+        # test fetching L factor
+        L = chol.L
+        U = chol.U
+        @test L[1:10,1:10]' == U[1:10,1:10]
+    end
+
     @testset "singularly perturbed" begin
         # using Symmetric(BandedMatrix(...))
         ε = 0.0001


### PR DESCRIPTION
Fixes https://github.com/JuliaLinearAlgebra/InfiniteLinearAlgebra.jl/issues/173

The issue arises because adaptive Cholesky factors can't be copied.

Here's a minimal example of the error before fixing:
```julia
z = 10_000;
A = BandedMatrix(0 => -2*(0:∞)/z, 1 => Ones(∞), -1 => Ones(∞));
M = Symmetric(I-A)

chol = cholesky(M)
copy(chol.factors') # fails as described in the issue

```

I will also add tests to verify `chol.L` and `copy()` don't silently break in the future.