### PR TITLE
Prevent runaway QL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteLinearAlgebra"
 uuid = "cde9dba0-b1de-11e9-2c62-0bab9446c55c"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infql.jl
+++ b/src/infql.jl
@@ -401,7 +401,7 @@ function initialadaptiveQLblock(A::AbstractMatrix{T}, tol) where T
         Ll = ql(A[checkinds:2N,checkinds:2N]).L[2:j-checkinds+1,2:j-checkinds+1]
         # compare bottom right sections and stop if desired level of convergence achieved
         Lerr = norm(Ll-Ls,2)
-        if N == maxN
+        if N >= maxN
             error("Reached max. iterations in adaptive QL without convergence to desired tolerance.")
         end
         Ls = Ll
@@ -449,7 +449,7 @@ function cache_filldata!(A::AdaptiveQLFactors{T}, inds::UnitRange{Int}) where T
         Ll = ql(A.M[checkinds:2N,checkinds:2N]).L[2:j-checkinds+1,2:j-checkinds+1]
         # compare bottom right sections and stop if desired level of convergence achieved
         Lerr = norm(Ll-Ls,2)
-        if N == maxN
+        if N >= maxN
             error("Reached max. iterations in adaptive QL without convergence to desired tolerance.")
         end
         Ls = Ll
@@ -470,7 +470,7 @@ function cache_filldata!(A::AdaptiveQLTau{T}, inds::UnitRange{Int}) where T
         Ll = ql(A.M[checkinds:2N,checkinds:2N]).L[2:j-checkinds+1,2:j-checkinds+1]
         # compare bottom right sections and stop if desired level of convergence achieved
         Lerr = norm(Ll-Ls,2)
-        if N == maxN
+        if N >= maxN
             error("Reached max. iterations in adaptive QL without convergence to desired tolerance.")
         end
         Ls = Ll

--- a/test/test_infql.jl
+++ b/test/test_infql.jl
@@ -219,6 +219,10 @@ using ArrayLayouts: TriangularLayout, UnknownLayout
             @test (L*b)[1:6] == ApplyArray(*,L,b)[1:6] == [0. , -5.25,  -7.833333333333333, -2.4166666666666666, -1., 0.]
             @test size(ql(A).τ) == (ℵ₀, )
         end
+        @testset "Naive extremely long / infinite loop protection" begin
+            A = _BandedMatrix(Vcat((((0:∞)))', (((1:∞)).+1/4)', Ones(1,∞)./3), ℵ₀, 1, 1)
+            @test_throws ErrorException("Reached max. iterations in adaptive QL without convergence to desired tolerance.") ql(A)
+        end
         @testset "Explicit tolerance tests" begin
             Asym = LinearAlgebra.SymTridiagonal([[1.,2.]; Fill(3.,∞)], [[1., 2.]; Fill(1.,∞)])
             Aplain = LinearAlgebra.Tridiagonal([[1., 2.]; Fill(1.,∞)], [[1.,2.]; Fill(3.,∞)], [[1., 2.]; Fill(1.,∞)])


### PR DESCRIPTION
I was looking at the design differences mentioned in the comments of https://github.com/JuliaLinearAlgebra/InfiniteLinearAlgebra.jl/pull/179 and spotted that these while loop protections in the (already existing) QL are very 'optimistic'. Doesn't seem to have caused issues for anyone but it still shouldn't enter an infinite loop.